### PR TITLE
Fixed Namespace not specified error and upgraded gradle properties.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:8.1.0'
     }
 }
 
@@ -22,7 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.zhgwu.shared_preferences_content_provider'
+    }
+    compileSdkVersion 35
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR fixes the build failure caused by a missing namespace in the :shared_preferences_content_provider module.

![image](https://github.com/user-attachments/assets/44173f7a-ad47-44bf-84d7-ec5298b8d31a)

**Root Cause:**
The build error occurred because the Android Gradle Plugin (AGP) now requires specifying a namespace in the module's build.gradle or build.gradle.kts file. Previously, the package attribute in the AndroidManifest.xml was sufficient, but AGP has transitioned to using the namespace property for improved clarity and modularization.

**Fix:**
Added the namespace property to the build.gradle file of the :shared_preferences_content_provider module.

The value for namespace was derived from the package attribute in the AndroidManifest.xml to ensure consistency.

This fix resolves the build failure and ensures compatibility with the latest AGP requirements.